### PR TITLE
Change URL to https to get more privacy

### DIFF
--- a/src/main/java/com/sahhiill/clashapi/core/Token/KeyHandler.java
+++ b/src/main/java/com/sahhiill/clashapi/core/Token/KeyHandler.java
@@ -91,7 +91,7 @@ public class KeyHandler {
      * @throws IOException
      */
     private String getIP() throws IOException {
-        java.net.URL url = new URL("http://checkip.amazonaws.com");
+        java.net.URL url = new URL("https://checkip.amazonaws.com");
         BufferedReader in = new BufferedReader(new InputStreamReader(
                 url.openStream()));
         return in.readLine();


### PR DESCRIPTION
IP addresses are a sensible peace of your data, protect them by using https instead of http.